### PR TITLE
Add explainer types in payload and return both LIME and SHAP by default

### DIFF
--- a/src/main/java/org/kie/trustyai/ConfigService.java
+++ b/src/main/java/org/kie/trustyai/ConfigService.java
@@ -8,7 +8,7 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 @ApplicationScoped
 public class ConfigService {
 
-    @ConfigProperty(name = "explainer.type", defaultValue = "LIME")
+    @ConfigProperty(name = "explainer.type")
     ExplainerType explainerType;
     @ConfigProperty(name = "lime.samples", defaultValue = "200")
     int limeSamples;
@@ -50,8 +50,7 @@ public class ConfigService {
     @PostConstruct
     private void validateConfig() {
         if (explainerType == null) {
-            Log.error("Unknown explainer type configured. Falling back to LIME.");
-            explainerType = ExplainerType.LIME;
+            Log.error("Unknown explainer type configured. Falling back to LIME and SHAP.");
         }
     }
 

--- a/src/main/java/org/kie/trustyai/payloads/SaliencyExplanationResponse.java
+++ b/src/main/java/org/kie/trustyai/payloads/SaliencyExplanationResponse.java
@@ -3,32 +3,35 @@ package org.kie.trustyai.payloads;
 import org.kie.trustyai.explainability.model.FeatureImportance;
 import org.kie.trustyai.explainability.model.Saliency;
 import org.kie.trustyai.explainability.model.SaliencyResults;
+import org.kie.trustyai.ExplainerType;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+
 public class SaliencyExplanationResponse extends BaseExplanationResponse {
 
-    protected Map<String, List<FeatureSaliency>> saliencies;
+    protected Map<ExplainerType, Map<String, List<FeatureSaliency>>> saliencies;
 
-    public SaliencyExplanationResponse(Map<String, List<FeatureSaliency>> saliencies) {
+    public SaliencyExplanationResponse(Map<ExplainerType, Map<String, List<FeatureSaliency>>> saliencies) {
         super();
         this.saliencies = saliencies;
     }
 
-    public Map<String, List<FeatureSaliency>> getSaliencies() {
+    public SaliencyExplanationResponse(){
+        //NO-OP
+    }
+
+    public Map<ExplainerType, Map<String, List<FeatureSaliency>>> getSaliencies() {
         return saliencies;
     }
 
-    public void setSaliencies(Map<String, List<FeatureSaliency>> saliencies) {
+    public void setSaliencies(Map<ExplainerType, Map<String, List<FeatureSaliency>>> saliencies) {
         this.saliencies = saliencies;
-    }
-
-    public SaliencyExplanationResponse() {
-        // NO-OP
     }
 
     @Override
@@ -83,9 +86,9 @@ public class SaliencyExplanationResponse extends BaseExplanationResponse {
         }
     }
 
-    public static SaliencyExplanationResponse fromSaliencyResults(@Nonnull SaliencyResults saliencyResults) {
-        Map<String, List<FeatureSaliency>> featureSaliencyMap = new HashMap<>();
-
+    public static SaliencyExplanationResponse fromSaliencyResults(ExplainerType explainerType, @Nonnull SaliencyResults saliencyResults) {
+        Map<ExplainerType, Map<String, List<FeatureSaliency>>> featureSaliencyMap = new HashMap<>();
+        featureSaliencyMap.put(explainerType, new HashMap<String,List<FeatureSaliency>>());
         for (Map.Entry<String, Saliency> saliencyMap : saliencyResults.getSaliencies().entrySet()) {
             List<FeatureSaliency> featureSaliencies = new ArrayList<>();
             String outputName = saliencyMap.getKey();
@@ -97,14 +100,51 @@ public class SaliencyExplanationResponse extends BaseExplanationResponse {
                 featureSaliency.setConfidence(featureImportance.getConfidence());
                 featureSaliencies.add(featureSaliency);
             }
-            featureSaliencyMap.put(outputName, featureSaliencies);
+            featureSaliencyMap.get(explainerType).put(outputName, featureSaliencies);
+        }
+        return new SaliencyExplanationResponse(featureSaliencyMap);
+    }
+
+        public static SaliencyExplanationResponse fromSaliencyResults(@Nonnull SaliencyResults limeResults, @Nonnull SaliencyResults shapResults) {
+        Map<String, List<FeatureSaliency>> limeSaliencyMap = new HashMap<>();
+        Map<String, List<FeatureSaliency>> shapSaliencyMap = new HashMap<>();
+
+        // Process LIME results
+        for (Map.Entry<String, Saliency> saliencyMap : limeResults.getSaliencies().entrySet()) {
+            List<FeatureSaliency> featureSaliencies = new ArrayList<>();
+            String outputName = saliencyMap.getKey();
+            Saliency saliency = saliencyMap.getValue();
+            for (FeatureImportance featureImportance : saliency.getPerFeatureImportance()) {
+                FeatureSaliency featureSaliency = new FeatureSaliency();
+                featureSaliency.setName(featureImportance.getFeature().getName());
+                featureSaliency.setScore(featureImportance.getScore());
+                featureSaliency.setConfidence(featureImportance.getConfidence());
+                featureSaliencies.add(featureSaliency);
+            }
+            limeSaliencyMap.put(outputName, featureSaliencies);
         }
 
-        return new SaliencyExplanationResponse(featureSaliencyMap);
+        // Process SHAP results
+        for (Map.Entry<String, Saliency> saliencyMap : shapResults.getSaliencies().entrySet()) {
+            List<FeatureSaliency> featureSaliencies = new ArrayList<>();
+            String outputName = saliencyMap.getKey();
+            Saliency saliency = saliencyMap.getValue();
+            for (FeatureImportance featureImportance : saliency.getPerFeatureImportance()) {
+                FeatureSaliency featureSaliency = new FeatureSaliency();
+                featureSaliency.setName(featureImportance.getFeature().getName());
+                featureSaliency.setScore(featureImportance.getScore());
+                featureSaliency.setConfidence(featureImportance.getConfidence());
+                featureSaliencies.add(featureSaliency);
+            }
+            shapSaliencyMap.put(outputName, featureSaliencies);
+        }
+
+        // Combine the results
+        Map<ExplainerType, Map<String, List<FeatureSaliency>>> combinedMap = new EnumMap<>(ExplainerType.class);
+        combinedMap.put(ExplainerType.LIME, limeSaliencyMap);
+        combinedMap.put(ExplainerType.SHAP, shapSaliencyMap);
+
+        return new SaliencyExplanationResponse(combinedMap);
     }
 
-    public static SaliencyExplanationResponse empty() {
-        Map<String, List<FeatureSaliency>> featureSaliencyMap = new HashMap<>();
-        return new SaliencyExplanationResponse(featureSaliencyMap);
-    }
 }


### PR DESCRIPTION
Addresses issue #8 by making the following changes:
* Updates `src/main/java/org/kie/trustyai/ConfigService.java` to return both LIME and SHAP
* Updates `src/main/java/org/kie/trustyai/ExplainerV1Endpoint.java` & `src/main/java/org/kie/trustyai/payloads/SaliencyExplanationResponse.java` with functionality to get both LIME and SHAP or either and adds the explainer type in the info

Currently, if the explainer type is null then we return both LIME and SHAP but let me know if I should create a new explainer type to be more explicit.
