### PR TITLE
Upgrade Trivy action to version 0.35.0

### DIFF
--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -26,7 +26,7 @@ jobs:
           distribution: "temurin"
 
       - name: Run Trivy vulnerability scan
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           scan-type: "fs"
           scan-ref: "."
@@ -36,7 +36,7 @@ jobs:
           exit-code: "0"
 
       - name: Check for critical and high vulnerabilities
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           scan-type: "fs"
           scan-ref: "."


### PR DESCRIPTION
Updated Trivy action version to v0.35.0 for vulnerability scans.

## Summary by Sourcery

CI:
- Bump Trivy GitHub Action in the security-scan workflow from v0.28.0 to the pinned commit for v0.35.0.